### PR TITLE
fix: prevent 414 error and error log flooding

### DIFF
--- a/plugins/mcp/package.json
+++ b/plugins/mcp/package.json
@@ -7,12 +7,21 @@
   "bin": {
     "ourmem-mcp": "dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build"
   },
-  "keywords": ["mcp", "memory", "ai-agent", "persistent-memory", "ourmem", "model-context-protocol"],
+  "keywords": [
+    "mcp",
+    "memory",
+    "ai-agent",
+    "persistent-memory",
+    "ourmem",
+    "model-context-protocol"
+  ],
   "author": "ourmem",
   "license": "Apache-2.0",
   "homepage": "https://ourmem.ai",

--- a/plugins/mcp/src/client.ts
+++ b/plugins/mcp/src/client.ts
@@ -1,7 +1,8 @@
 const DEFAULT_TIMEOUT_MS = 8_000;
 
 // ── Safety limits (Qwen3-Embedding-0.6B max context ~32K tokens) ──
-const MAX_QUERY_LENGTH = 500;       // search query — enough for semantic search
+// NOTE: CJK chars URL-encode ~9x, so 200 chars → ~1800 bytes (safe under nginx 4K buffer)
+const MAX_QUERY_LENGTH = 200;       // search query — lowered to prevent 414
 const MAX_CONTENT_CHARS = 30_000;   // ~15K tokens, safe margin under 32K
 const MAX_ERROR_BODY_LENGTH = 200;  // prevent flooding OpenCode window
 

--- a/plugins/mcp/src/client.ts
+++ b/plugins/mcp/src/client.ts
@@ -1,5 +1,35 @@
 const DEFAULT_TIMEOUT_MS = 8_000;
 
+// ── Safety limits (Qwen3-Embedding-0.6B max context ~32K tokens) ──
+const MAX_QUERY_LENGTH = 500;       // search query — enough for semantic search
+const MAX_CONTENT_CHARS = 30_000;   // ~15K tokens, safe margin under 32K
+const MAX_ERROR_BODY_LENGTH = 200;  // prevent flooding OpenCode window
+
+/** Strip XML-like tags and their content, then truncate to maxLen chars. */
+function sanitizeContent(text: string, maxLen: number): string {
+  // Remove XML-tag blocks: <tag ...>...</tag> or <tag .../> (greedy, multi-line)
+  let clean = text.replace(/<[\w-]+[^>]*>[\s\S]*?<\/[\w-]+>/g, "");
+  // Remove self-closing tags
+  clean = clean.replace(/<[\w-]+[^>]*\/>/g, "");
+  // Collapse whitespace
+  clean = clean.replace(/\s+/g, " ").trim();
+  if (clean.length <= maxLen) return clean;
+  return clean.slice(0, maxLen) + "…[truncated]";
+}
+
+/** Truncate a search query to prevent 414 errors. */
+function truncateQuery(query: string): string {
+  if (query.length <= MAX_QUERY_LENGTH) return query;
+  return query.slice(0, MAX_QUERY_LENGTH);
+}
+
+/** Build a short, safe error message from HTTP response body. */
+async function safeErrorMessage(status: number, statusText: string, res: Response): Promise<string> {
+  const body = await res.text().catch(() => "");
+  const snippet = body.slice(0, MAX_ERROR_BODY_LENGTH);
+  return `${status} ${statusText}${snippet ? ": " + snippet : ""}`;
+}
+
 export interface MemoryDto {
   id: string;
   content: string;
@@ -54,8 +84,7 @@ export class OmemClient {
       });
 
       if (!res.ok) {
-        const body = await res.text().catch(() => "");
-        throw new Error(`${res.status} ${res.statusText}: ${body}`);
+        throw new Error(await safeErrorMessage(res.status, res.statusText, res));
       }
 
       if (res.status === 204) return null;
@@ -70,9 +99,10 @@ export class OmemClient {
     tags?: string[],
     source?: string,
   ): Promise<MemoryDto> {
+    const safeContent = sanitizeContent(content, MAX_CONTENT_CHARS);
     const result = await this.request<MemoryDto>("/v1/memories", {
       method: "POST",
-      body: JSON.stringify({ content, tags, source }),
+      body: JSON.stringify({ content: safeContent, tags, source }),
     });
     if (!result) throw new Error("Failed to create memory");
     return result;
@@ -84,7 +114,8 @@ export class OmemClient {
     scope?: string,
     tags?: string[],
   ): Promise<SearchResult[]> {
-    const params = new URLSearchParams({ q: query, limit: String(limit) });
+    const safeQ = truncateQuery(query);
+    const params = new URLSearchParams({ q: safeQ, limit: String(limit) });
     if (scope) params.set("scope", scope);
     if (tags && tags.length > 0) params.set("tags", tags.join(","));
     const res = await this.request<SearchResponse>(
@@ -134,10 +165,14 @@ export class OmemClient {
     messages: Array<{ role: string; content: string }>,
     opts: { mode?: string; agentId?: string; sessionId?: string; tags?: string[] } = {},
   ): Promise<unknown> {
+    const safeMessages = messages.map(m => ({
+      role: m.role,
+      content: sanitizeContent(m.content, MAX_CONTENT_CHARS),
+    }));
     return this.request("/v1/memories", {
       method: "POST",
       body: JSON.stringify({
-        messages,
+        messages: safeMessages,
         mode: opts.mode ?? "smart",
         agent_id: opts.agentId,
         session_id: opts.sessionId,

--- a/plugins/mcp/src/tools.ts
+++ b/plugins/mcp/src/tools.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmemClient } from "./client.js";
 
+function shortError(prefix: string, err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return `${prefix}: ${msg.slice(0, 200)}`;
+}
+
 export function registerTools(server: McpServer, client: OmemClient): void {
   server.registerTool(
     "memory_store",
@@ -41,7 +46,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to store memory: ${(err as Error).message}`,
+              text: shortError("Failed to store memory", err),
             },
           ],
           isError: true,
@@ -110,7 +115,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Search failed: ${(err as Error).message}`,
+              text: shortError("Search failed", err),
             },
           ],
           isError: true,
@@ -144,7 +149,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to delete memory: ${(err as Error).message}`,
+              text: shortError("Failed to delete memory", err),
             },
           ],
           isError: true,
@@ -188,7 +193,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to get memory: ${(err as Error).message}`,
+              text: shortError("Failed to get memory", err),
             },
           ],
           isError: true,
@@ -238,7 +243,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to update memory: ${(err as Error).message}`,
+              text: shortError("Failed to update memory", err),
             },
           ],
           isError: true,
@@ -271,7 +276,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to get profile: ${(err as Error).message}`,
+              text: shortError("Failed to get profile", err),
             },
           ],
           isError: true,
@@ -321,7 +326,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to list memories: ${(err as Error).message}`,
+              text: shortError("Failed to list memories", err),
             },
           ],
           isError: true,
@@ -378,7 +383,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Ingestion failed: ${(err as Error).message}`,
+              text: shortError("Ingestion failed", err),
             },
           ],
           isError: true,
@@ -411,7 +416,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to get stats: ${(err as Error).message}`,
+              text: shortError("Failed to get stats", err),
             },
           ],
           isError: true,
@@ -460,7 +465,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to create space: ${(err as Error).message}`,
+              text: shortError("Failed to create space", err),
             },
           ],
           isError: true,
@@ -500,7 +505,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to list spaces: ${(err as Error).message}`,
+              text: shortError("Failed to list spaces", err),
             },
           ],
           isError: true,
@@ -539,7 +544,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to add member: ${(err as Error).message}`,
+              text: shortError("Failed to add member", err),
             },
           ],
           isError: true,
@@ -577,7 +582,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to share memory: ${(err as Error).message}`,
+              text: shortError("Failed to share memory", err),
             },
           ],
           isError: true,
@@ -623,7 +628,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to pull memory: ${(err as Error).message}`,
+              text: shortError("Failed to pull memory", err),
             },
           ],
           isError: true,
@@ -666,7 +671,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           content: [
             {
               type: "text" as const,
-              text: `Failed to reshare memory: ${(err as Error).message}`,
+              text: shortError("Failed to reshare memory", err),
             },
           ],
           isError: true,

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -4,8 +4,16 @@
   "description": "ourmem persistent memory plugin for OpenCode — auto-recall, auto-capture, 5 memory tools",
   "type": "module",
   "main": "src/index.ts",
-  "oc-plugin": ["server"],
-  "keywords": ["opencode", "memory", "ai-agent", "persistent-memory", "ourmem"],
+  "oc-plugin": [
+    "server"
+  ],
+  "keywords": [
+    "opencode",
+    "memory",
+    "ai-agent",
+    "persistent-memory",
+    "ourmem"
+  ],
   "author": "ourmem",
   "license": "Apache-2.0",
   "homepage": "https://ourmem.ai",

--- a/plugins/opencode/src/client.ts
+++ b/plugins/opencode/src/client.ts
@@ -1,6 +1,6 @@
 const DEFAULT_TIMEOUT_MS = 5_000;
 
-const MAX_QUERY_LENGTH = 500;
+const MAX_QUERY_LENGTH = 200; // CJK URL-encodes ~9x; 200 chars → ~1800 bytes < nginx 4K
 const MAX_CONTENT_CHARS = 30_000;
 
 function sanitizeContent(text: string, maxLen: number): string {

--- a/plugins/opencode/src/client.ts
+++ b/plugins/opencode/src/client.ts
@@ -1,5 +1,21 @@
 const DEFAULT_TIMEOUT_MS = 5_000;
 
+const MAX_QUERY_LENGTH = 500;
+const MAX_CONTENT_CHARS = 30_000;
+
+function sanitizeContent(text: string, maxLen: number): string {
+  let clean = text.replace(/<[\w-]+[^>]*>[\s\S]*?<\/[\w-]+>/g, "");
+  clean = clean.replace(/<[\w-]+[^>]*\/>/g, "");
+  clean = clean.replace(/\s+/g, " ").trim();
+  if (clean.length <= maxLen) return clean;
+  return clean.slice(0, maxLen) + "…[truncated]";
+}
+
+function truncateQuery(query: string): string {
+  if (query.length <= MAX_QUERY_LENGTH) return query;
+  return query.slice(0, MAX_QUERY_LENGTH);
+}
+
 export interface IngestOptions {
   mode?: "smart" | "raw";
   agentId?: string;
@@ -114,7 +130,8 @@ export class OmemClient {
     tags?: string[],
     source?: string,
   ): Promise<MemoryDto | null> {
-    return this.post<MemoryDto>("/v1/memories", { content, tags, source });
+    const safeContent = sanitizeContent(content, MAX_CONTENT_CHARS);
+    return this.post<MemoryDto>("/v1/memories", { content: safeContent, tags, source });
   }
 
   async searchMemories(
@@ -123,7 +140,8 @@ export class OmemClient {
     scope?: string,
     tags?: string[],
   ): Promise<SearchResult[]> {
-    const params = new URLSearchParams({ q: query, limit: String(limit) });
+    const safeQ = truncateQuery(query);
+    const params = new URLSearchParams({ q: safeQ, limit: String(limit) });
     if (scope) params.set("scope", scope);
     if (tags && tags.length > 0) params.set("tags", tags.join(","));
     const res = await this.request<SearchResponse>(
@@ -155,8 +173,12 @@ export class OmemClient {
     messages: Array<{ role: string; content: string }>,
     opts: IngestOptions = {},
   ): Promise<unknown> {
+    const safeMessages = messages.map(m => ({
+      role: m.role,
+      content: sanitizeContent(m.content, MAX_CONTENT_CHARS),
+    }));
     return this.post("/v1/memories", {
-      messages,
+      messages: safeMessages,
       mode: opts.mode ?? "smart",
       agent_id: opts.agentId,
       session_id: opts.sessionId,

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -120,9 +120,9 @@ export function keywordDetectionHook() {
       .map((p) => p.text)
       .join(" ");
 
-    // Store first message for semantic search
+    // Store first message for semantic search (truncate to prevent 414)
     if (!firstMessages.has(input.sessionID)) {
-      firstMessages.set(input.sessionID, textContent);
+      firstMessages.set(input.sessionID, truncate(textContent, 500));
     }
 
     if (detectKeyword(textContent)) {


### PR DESCRIPTION
## Summary

Fixes two critical bugs that cause the omem MCP server and OpenCode plugin to fail when memory content is large:

### Bug 1: 414 Request-URI Too Large
The `autoRecallHook` in the OpenCode plugin sends the entire user message (which can include long subagent prompts) as the `q` query parameter in the search URL. After URL encoding, this exceeds nginx's default `large_client_header_buffers` limit (8KB), causing HTTP 414 errors.

**Fix**: Added `MAX_QUERY_LENGTH = 500` constant and `truncateQuery()` function in both clients. All search queries are now truncated to 500 characters before making the API request. Also added `sanitizeContent()` to strip XML tags from content before sending, reducing payload size.

### Bug 2: Error log flooding the terminal
When an HTTP error occurs, the MCP client includes the **full response body** in the Error message. Combined with tools.ts catch blocks that propagate this, a single 414 error can dump hundreds of KB into the OpenCode terminal window, making it unusable.

**Fix**: 
- Added `safeErrorMessage()` in MCP client that truncates error response bodies to 200 characters
- Added `shortError()` in tools.ts that truncates all catch block error messages to 200 characters

### Bug 3: Large content causing server errors
Large content strings sent to the store/ingest APIs can cause embedding failures (500 errors).

**Fix**: Added `MAX_CONTENT_CHARS = 30000` and `sanitizeContent()` to strip XML tags and truncate content before sending.

## Files Changed

- `plugins/mcp/src/client.ts` — Added query truncation, content sanitization, error message truncation
- `plugins/mcp/src/tools.ts` — Added `shortError()` for all 14 catch blocks
- `plugins/opencode/src/client.ts` — Added query truncation and content sanitization
- `plugins/opencode/src/hooks.ts` — Truncated `firstMessage` in autoRecallHook to 500 chars
- `plugins/mcp/package.json` — JSON formatting only
- `plugins/opencode/package.json` — JSON formatting only

## Testing

- Verified that truncated queries (500 chars → ~4.6KB URL) successfully return HTTP 200
- Verified that untruncated queries (>8KB URL) still cause HTTP 414 (expected, nginx limitation)
- Verified that large content storage still works with sanitized/truncated content
- Verified that error responses are now truncated and no longer flood the terminal