### PR TITLE
feat(store): make Lance vector dimension configurable, derive from embedder

### DIFF
--- a/omem-server/src/main.rs
+++ b/omem-server/src/main.rs
@@ -36,7 +36,19 @@ async fn main() {
     );
 
     let base_uri = config.store_uri();
-    let store_manager = Arc::new(StoreManager::new(&base_uri));
+
+    // Build the embedder first so we can size the Lance vector column to
+    // exactly match what the model produces. Lets users plug in any embedding
+    // model (384-, 768-, 1024-dim, etc.) without recompiling.
+    let embed: Arc<dyn EmbedService> = Arc::from(
+        create_embed_service(&config)
+            .await
+            .expect("failed to create embed service"),
+    );
+    let vector_dim: i32 = embed.dimensions().try_into().expect("embedding dim does not fit in i32");
+    tracing::info!(vector_dim, "embedder reported vector dimension");
+
+    let store_manager = Arc::new(StoreManager::with_vector_dim(&base_uri, vector_dim));
 
     let system_uri = format!("{}/_system", base_uri);
     let tenant_store = Arc::new(
@@ -52,12 +64,6 @@ async fn main() {
             .expect("failed to create SpaceStore"),
     );
     space_store.init_tables().await.expect("failed to init spaces tables");
-
-    let embed: Arc<dyn EmbedService> = Arc::from(
-        create_embed_service(&config)
-            .await
-            .expect("failed to create embed service"),
-    );
 
     let llm: Arc<dyn LlmService> = Arc::from(
         create_llm_service(&config)

--- a/omem-server/src/store/lancedb.rs
+++ b/omem-server/src/store/lancedb.rs
@@ -21,7 +21,7 @@ use crate::domain::relation::MemoryRelation;
 use crate::domain::space::Provenance;
 use crate::domain::types::{MemoryState, MemoryType, Tier};
 
-const VECTOR_DIM: i32 = 1024;
+pub const DEFAULT_VECTOR_DIM: i32 = 1024;
 const TABLE_NAME: &str = "memories";
 
 pub struct ListFilter {
@@ -51,11 +51,24 @@ impl Default for ListFilter {
 pub struct LanceStore {
     db: Connection,
     table_name: String,
+    vector_dim: i32,
     fts_indexed: AtomicBool,
 }
 
 impl LanceStore {
+    /// Construct with the default 1024-dim vector schema (back-compat).
     pub async fn new(uri: &str) -> Result<Self, OmemError> {
+        Self::with_dim(uri, DEFAULT_VECTOR_DIM).await
+    }
+
+    /// Construct with an explicit vector dimension. Must match the
+    /// `dimensions()` reported by the active `EmbedService`.
+    pub async fn with_dim(uri: &str, vector_dim: i32) -> Result<Self, OmemError> {
+        if vector_dim <= 0 {
+            return Err(OmemError::Storage(format!(
+                "invalid vector_dim {vector_dim}: must be > 0"
+            )));
+        }
         let mut builder = lancedb::connect(uri);
 
         // For S3-compatible stores (e.g., Alibaba Cloud OSS), pass through
@@ -78,8 +91,14 @@ impl LanceStore {
         Ok(Self {
             db,
             table_name: TABLE_NAME.to_string(),
+            vector_dim,
             fts_indexed: AtomicBool::new(false),
         })
+    }
+
+    /// Dimension of vectors stored in this table.
+    pub fn vector_dim(&self) -> i32 {
+        self.vector_dim
     }
 
     pub async fn init_table(&self) -> Result<(), OmemError> {
@@ -92,7 +111,7 @@ impl LanceStore {
 
         if !existing.contains(&self.table_name) {
             self.db
-                .create_empty_table(&self.table_name, Self::schema())
+                .create_empty_table(&self.table_name, self.schema())
                 .execute()
                 .await
                 .map_err(|e| OmemError::Storage(format!("failed to create table: {e}")))?;
@@ -105,7 +124,22 @@ impl LanceStore {
             .schema()
             .await
             .map_err(|e| OmemError::Storage(format!("failed to get table schema: {e}")))?;
-        let expected_schema = Self::schema();
+        let expected_schema = self.schema();
+
+        // Validate that the existing table's vector column matches our configured dim,
+        // so a model swap that changes dimensions fails loudly at startup rather than
+        // panicking deep in Arrow on the first write/read.
+        if let Ok(vector_field) = current_schema.field_with_name("vector") {
+            if let DataType::FixedSizeList(_, existing_dim) = vector_field.data_type() {
+                if *existing_dim != self.vector_dim {
+                    return Err(OmemError::Storage(format!(
+                        "vector dim mismatch: table has {} but embedder produces {}; \
+                         wipe the table or switch back to the matching embedding model",
+                        existing_dim, self.vector_dim
+                    )));
+                }
+            }
+        }
 
         let missing_fields: Vec<Field> = expected_schema
             .fields()
@@ -127,7 +161,7 @@ impl LanceStore {
         Ok(())
     }
 
-    fn schema() -> Arc<Schema> {
+    fn schema(&self) -> Arc<Schema> {
         Arc::new(Schema::new(vec![
             Field::new("id", DataType::Utf8, false),
             Field::new("content", DataType::Utf8, false),
@@ -138,7 +172,7 @@ impl LanceStore {
                 "vector",
                 DataType::FixedSizeList(
                     Arc::new(Field::new("item", DataType::Float32, true)),
-                    VECTOR_DIM,
+                    self.vector_dim,
                 ),
                 true,
             ),
@@ -178,7 +212,7 @@ impl LanceStore {
             .map_err(|e| OmemError::Storage(format!("failed to open table: {e}")))
     }
 
-    fn memory_to_batch(memory: &Memory, vector: Option<&[f32]>) -> Result<RecordBatch, OmemError> {
+    fn memory_to_batch(&self, memory: &Memory, vector: Option<&[f32]>) -> Result<RecordBatch, OmemError> {
         let tags_json = serde_json::to_string(&memory.tags)
             .map_err(|e| OmemError::Storage(format!("failed to serialize tags: {e}")))?;
         let relations_json = serde_json::to_string(&memory.relations)
@@ -191,13 +225,22 @@ impl LanceStore {
             .map_err(|e| OmemError::Storage(format!("failed to serialize provenance: {e}")))?;
 
         let vec_data: Vec<f32> = match vector {
-            Some(v) => v.to_vec(),
-            None => vec![0.0; VECTOR_DIM as usize],
+            Some(v) => {
+                if v.len() != self.vector_dim as usize {
+                    return Err(OmemError::Storage(format!(
+                        "embedding length {} does not match table vector_dim {}",
+                        v.len(),
+                        self.vector_dim
+                    )));
+                }
+                v.to_vec()
+            }
+            None => vec![0.0; self.vector_dim as usize],
         };
 
         let vector_array = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
             vec![Some(vec_data.into_iter().map(Some).collect::<Vec<_>>())],
-            VECTOR_DIM,
+            self.vector_dim,
         );
 
         let provenance_source_id: Option<&str> = memory
@@ -206,7 +249,7 @@ impl LanceStore {
             .map(|p| p.shared_from_memory.as_str());
 
         RecordBatch::try_new(
-            Self::schema(),
+            self.schema(),
             vec![
                 Arc::new(StringArray::from(vec![memory.id.as_str()])),
                 Arc::new(StringArray::from(vec![memory.content.as_str()])),
@@ -423,9 +466,9 @@ impl LanceStore {
         memory: &Memory,
         vector: Option<&[f32]>,
     ) -> Result<(), OmemError> {
-        let batch = Self::memory_to_batch(memory, vector)?;
+        let batch = self.memory_to_batch(memory, vector)?;
         let table = self.open_table().await?;
-        let reader = RecordBatchIterator::new(vec![Ok(batch)], Self::schema());
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], self.schema());
         table
             .add(Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
             .execute()
@@ -518,8 +561,8 @@ impl LanceStore {
             .await
             .map_err(|e| OmemError::Storage(format!("delete for update failed: {e}")))?;
 
-        let batch = Self::memory_to_batch(&mem, vector)?;
-        let reader = RecordBatchIterator::new(vec![Ok(batch)], Self::schema());
+        let batch = self.memory_to_batch(&mem, vector)?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], self.schema());
         table
             .add(Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
             .execute()
@@ -899,6 +942,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_with_dim_stores_correct_dimension() {
+        // 384 is a common smaller-model dim (e.g. all-MiniLM, bge-small).
+        let dir = TempDir::new().expect("temp dir");
+        let store = LanceStore::with_dim(dir.path().to_str().unwrap(), 384)
+            .await
+            .expect("with_dim should construct");
+        store.init_table().await.expect("init_table");
+        assert_eq!(store.vector_dim(), 384);
+
+        // Store + retrieve a memory with a 384-dim vector — should round-trip.
+        let mem = make_memory("t-384", "tiny embedding test");
+        let v = vec![0.1f32; 384];
+        store.create(&mem, Some(&v)).await.expect("create with 384-dim vector");
+        let fetched = store.get_by_id(&mem.id).await.unwrap().expect("memory");
+        assert_eq!(fetched.id, mem.id);
+    }
+
+    #[tokio::test]
+    async fn test_with_dim_rejects_wrong_length_vector() {
+        let dir = TempDir::new().expect("temp dir");
+        let store = LanceStore::with_dim(dir.path().to_str().unwrap(), 384)
+            .await
+            .expect("with_dim");
+        store.init_table().await.expect("init_table");
+
+        let mem = make_memory("t-bad", "wrong-dim test");
+        let v = vec![0.1f32; 768]; // wrong size for a 384-dim table
+        let err = store.create(&mem, Some(&v)).await.expect_err("should reject");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("does not match"), "unexpected error: {msg}");
+    }
+
+    #[tokio::test]
+    async fn test_init_table_rejects_dim_mismatch_on_reopen() {
+        // Create a table at 384 dim, drop, then try to reopen at 1024 dim.
+        let dir = TempDir::new().expect("temp dir");
+        let uri = dir.path().to_str().unwrap().to_string();
+        {
+            let store = LanceStore::with_dim(&uri, 384).await.expect("with_dim 384");
+            store.init_table().await.expect("init_table");
+        }
+        let store = LanceStore::with_dim(&uri, 1024)
+            .await
+            .expect("with_dim 1024");
+        let err = store.init_table().await.expect_err("dim mismatch should error");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("dim mismatch") || msg.contains("vector dim"), "unexpected error: {msg}");
+    }
+
+    #[tokio::test]
     async fn test_create_and_get_by_id() {
         let (store, _dir) = setup().await;
         let mem = make_memory("t-001", "user prefers dark mode");
@@ -925,12 +1018,12 @@ mod tests {
     async fn test_vector_search() {
         let (store, _dir) = setup().await;
 
-        let mut v1 = vec![0.0f32; VECTOR_DIM as usize];
+        let mut v1 = vec![0.0f32; DEFAULT_VECTOR_DIM as usize];
         v1[0] = 1.0;
-        let mut v2 = vec![0.0f32; VECTOR_DIM as usize];
+        let mut v2 = vec![0.0f32; DEFAULT_VECTOR_DIM as usize];
         v2[0] = 0.9;
         v2[1] = 0.1;
-        let mut v3 = vec![0.0f32; VECTOR_DIM as usize];
+        let mut v3 = vec![0.0f32; DEFAULT_VECTOR_DIM as usize];
         v3[1] = 1.0;
 
         let m1 = make_memory("t-001", "closest match");
@@ -941,7 +1034,7 @@ mod tests {
         store.create(&m2, Some(&v2)).await.unwrap();
         store.create(&m3, Some(&v3)).await.unwrap();
 
-        let mut query_vec = vec![0.0f32; VECTOR_DIM as usize];
+        let mut query_vec = vec![0.0f32; DEFAULT_VECTOR_DIM as usize];
         query_vec[0] = 1.0;
 
         let results = store
@@ -1019,9 +1112,9 @@ mod tests {
         let (store_a, _dir_a) = setup().await;
         let (store_b, _dir_b) = setup().await;
 
-        let mut va = vec![0.0f32; VECTOR_DIM as usize];
+        let mut va = vec![0.0f32; DEFAULT_VECTOR_DIM as usize];
         va[0] = 1.0;
-        let mut vb = vec![0.0f32; VECTOR_DIM as usize];
+        let mut vb = vec![0.0f32; DEFAULT_VECTOR_DIM as usize];
         vb[0] = 1.0;
 
         let mem_a = make_memory("tenant_A", "secret data for A");
@@ -1190,7 +1283,7 @@ mod tests {
             .unwrap();
 
         let old_schema = Arc::new(Schema::new(
-            LanceStore::schema()
+            store.schema()
                 .fields()
                 .iter()
                 .filter(|f| f.name() != "version" && f.name() != "provenance_source_id")
@@ -1248,7 +1341,7 @@ mod tests {
             .unwrap();
 
         let old_schema = Arc::new(Schema::new(
-            LanceStore::schema()
+            store.schema()
                 .fields()
                 .iter()
                 .filter(|f| f.name() != "provenance_source_id")

--- a/omem-server/src/store/manager.rs
+++ b/omem-server/src/store/manager.rs
@@ -4,7 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::domain::error::OmemError;
 use crate::domain::space::{MemberRole, Space, SpaceType};
-use super::lancedb::LanceStore;
+use super::lancedb::{LanceStore, DEFAULT_VECTOR_DIM};
 
 const DEFAULT_MAX_CACHED: usize = 1000;
 
@@ -29,14 +29,22 @@ pub struct AccessibleStore {
 
 pub struct StoreManager {
     base_uri: String,
+    vector_dim: i32,
     cache: Mutex<HashMap<String, CacheEntry>>,
     max_cached: usize,
 }
 
 impl StoreManager {
+    /// Construct with the default 1024-dim vector schema (back-compat for callers
+    /// that don't yet pass an embed-derived dim).
     pub fn new(base_uri: &str) -> Self {
+        Self::with_vector_dim(base_uri, DEFAULT_VECTOR_DIM)
+    }
+
+    pub fn with_vector_dim(base_uri: &str, vector_dim: i32) -> Self {
         Self {
             base_uri: base_uri.trim_end_matches('/').to_string(),
+            vector_dim,
             cache: Mutex::new(HashMap::new()),
             max_cached: DEFAULT_MAX_CACHED,
         }
@@ -46,9 +54,14 @@ impl StoreManager {
     pub fn with_max_cached(base_uri: &str, max_cached: usize) -> Self {
         Self {
             base_uri: base_uri.trim_end_matches('/').to_string(),
+            vector_dim: DEFAULT_VECTOR_DIM,
             cache: Mutex::new(HashMap::new()),
             max_cached,
         }
+    }
+
+    pub fn vector_dim(&self) -> i32 {
+        self.vector_dim
     }
 
     pub async fn get_store(&self, tenant_id: &str) -> Result<Arc<LanceStore>, OmemError> {
@@ -71,7 +84,7 @@ impl StoreManager {
         }
 
         let uri = format!("{}/{}", self.base_uri, tenant_id);
-        let store = LanceStore::new(&uri).await?;
+        let store = LanceStore::with_dim(&uri, self.vector_dim).await?;
         store.init_table().await?;
         let store = Arc::new(store);
 


### PR DESCRIPTION
## Summary

Lifts the hardcoded `const VECTOR_DIM: i32 = 1024;` in `src/store/lancedb.rs` so omem-server can be deployed with any embedding model whose dimension is reported by `EmbedService::dimensions()`. The `LanceStore` struct carries the dim as a field; `schema()` and `memory_to_batch()` become methods that read `self.vector_dim`. `main.rs` builds the embedder first, then sizes the store accordingly.

## Motivation

Running omem-server on CPU-only / non-AVX-512 hardware. `mxbai-embed-large` (1024-dim, 334M-param BERT) takes hundreds of ms per embed on older Xeons (e.g. E5-2697 v2 vintage). Smaller models — `bge-small-en-v1.5`, `all-MiniLM-L6-v2` (both 384-dim) — are several times faster per call but currently unusable because the store schema is locked to 1024.

The current behavior also fails ugly: any model whose dim != 1024 makes the server panic deep in Arrow on first read/write with `Length of the child array (768) must be the multiple of the value length (1024)`. This PR catches the mismatch up front with a clear `OmemError`.

## Back-compat

- `LanceStore::new(uri)` and `StoreManager::new(uri)` still default to 1024-dim — existing callers (tests, connectors, downstream code) keep working with zero changes.
- `DEFAULT_VECTOR_DIM` is exposed as a public const for tests / mocks.
- The Bedrock embedder is unchanged (still hardcoded to 1024 since that's Titan's native dim).
- No DB migration needed for existing 1024-dim deployments.

## Validation at startup

`init_table()` now compares the persisted table's vector-column dim against the configured value:
- Match: proceed normally
- Mismatch: return `OmemError::Storage("vector dim mismatch: table has X but embedder produces Y; wipe the table or switch back to the matching embedding model")` so the operator sees the problem immediately instead of a stacktrace in Arrow internals.

`memory_to_batch()` similarly rejects writes whose vector length doesn't match `self.vector_dim`, catching dimension drift before it corrupts data.

## Tests

Three new tests on `LanceStore` cover the new surface:
- `test_with_dim_stores_correct_dimension` — construct at 384, round-trip a 384-dim vector
- `test_with_dim_rejects_wrong_length_vector` — feeding a 768-dim vec into a 384-dim store errors cleanly
- `test_init_table_rejects_dim_mismatch_on_reopen` — reopening an existing table with a different configured dim errors loudly

All existing `store::lancedb::tests::*` continue to pass (they go through the default 1024-dim path).

## How verified

Built and tested via Forgejo Actions on my own infra (act_runner v6.3.1, stable rustc). The three new tests pass; existing store tests pass.

*Note for maintainers*: I noticed a few pre-existing test failures on upstream main unrelated to this PR — rustls 0.23 needs `CryptoProvider::install_default()` before any test that uses reqwest (20 `No provider set` panics in `connectors::github::tests`, `embed::openai_compat::tests`, `llm::openai_compat::tests`, `retrieve::reranker::tests`); plus 5 `api::tests` space-membership tests asserting 200 but getting 404. Happy to file those as separate issues if they're news.

## Checklist

- [x] Existing tests pass (in the modules touched by this change)
- [x] New behavior covered by tests
- [x] Back-compat preserved for `LanceStore::new()` callers
- [x] No new dependencies