### PR TITLE
feat(embed): configurable embedding dim + ollama timeout via env

### DIFF
--- a/omem-server/src/config.rs
+++ b/omem-server/src/config.rs
@@ -14,6 +14,8 @@ pub struct OmemConfig {
     pub embed_api_key: String,
     pub embed_base_url: String,
     pub embed_model: String,
+    pub embed_dim: usize,
+    pub embed_timeout_secs: u64,
 }
 
 impl Default for OmemConfig {
@@ -31,6 +33,8 @@ impl Default for OmemConfig {
             embed_api_key: String::new(),
             embed_base_url: String::new(),
             embed_model: String::new(),
+            embed_dim: 1024,
+            embed_timeout_secs: 10,
         }
     }
 }
@@ -54,6 +58,14 @@ impl OmemConfig {
             embed_api_key: env::var("OMEM_EMBED_API_KEY").unwrap_or(defaults.embed_api_key),
             embed_base_url: env::var("OMEM_EMBED_BASE_URL").unwrap_or(defaults.embed_base_url),
             embed_model: env::var("OMEM_EMBED_MODEL").unwrap_or(defaults.embed_model),
+            embed_dim: env::var("OMEM_EMBED_DIM")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.embed_dim),
+            embed_timeout_secs: env::var("OMEM_EMBED_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.embed_timeout_secs),
         }
     }
 

--- a/omem-server/src/embed/openai_compat.rs
+++ b/omem-server/src/embed/openai_compat.rs
@@ -8,7 +8,7 @@ use crate::embed::service::EmbedService;
 
 const MAX_BATCH_SIZE: usize = 25;
 const MAX_RETRIES: u32 = 3;
-const TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Serialize)]
 struct EmbeddingRequest {
@@ -53,8 +53,13 @@ impl OpenAICompatEmbedder {
             );
         }
 
+        let timeout_secs = if config.embed_timeout_secs > 0 {
+            config.embed_timeout_secs
+        } else {
+            DEFAULT_TIMEOUT_SECS
+        };
         let client = reqwest::Client::builder()
-            .timeout(TIMEOUT)
+            .timeout(Duration::from_secs(timeout_secs))
             .default_headers(headers)
             .build()
             .map_err(|e| OmemError::Embedding(format!("failed to build http client: {e}")))?;
@@ -63,7 +68,7 @@ impl OpenAICompatEmbedder {
             client,
             url: format!("{base_url}/v1/embeddings"),
             model: config.embed_model.clone(),
-            dims: 1024,
+            dims: if config.embed_dim > 0 { config.embed_dim } else { 1024 },
         })
     }
 
@@ -170,5 +175,43 @@ mod tests {
         };
         let embedder = OpenAICompatEmbedder::new(&config).unwrap();
         assert_eq!(embedder.url, "http://localhost:8000/v1/embeddings");
+    }
+
+    #[test]
+    fn embed_dim_from_config_overrides_default() {
+        // 384 is a common smaller-model dim (all-MiniLM, bge-small).
+        let config = OmemConfig {
+            embed_base_url: "http://localhost:11434".to_string(),
+            embed_dim: 384,
+            ..OmemConfig::default()
+        };
+        let embedder = OpenAICompatEmbedder::new(&config).unwrap();
+        assert_eq!(embedder.dimensions(), 384);
+    }
+
+    #[test]
+    fn embed_dim_zero_falls_back_to_1024() {
+        // Guards against misconfiguration that would produce zero-length vectors.
+        let config = OmemConfig {
+            embed_base_url: "http://localhost:11434".to_string(),
+            embed_dim: 0,
+            ..OmemConfig::default()
+        };
+        let embedder = OpenAICompatEmbedder::new(&config).unwrap();
+        assert_eq!(embedder.dimensions(), 1024);
+    }
+
+    #[test]
+    fn embed_timeout_zero_falls_back_to_default() {
+        // Constructor must not pass a 0s timeout to reqwest (would block forever
+        // or return immediately depending on version). Defaults to 10s when 0.
+        let config = OmemConfig {
+            embed_base_url: "http://localhost:11434".to_string(),
+            embed_timeout_secs: 0,
+            ..OmemConfig::default()
+        };
+        // Just assert construction succeeds — timeout itself is baked into the
+        // reqwest client and not externally observable without sending traffic.
+        OpenAICompatEmbedder::new(&config).expect("construction with timeout=0 should fall back");
     }
 }


### PR DESCRIPTION
## Summary

Makes two values in the openai-compat embedder configurable instead of hardcoded:

- `OMEM_EMBED_DIM` (default 1024) — drives `OpenAICompatEmbedder::dims` / `EmbedService::dimensions()`
- `OMEM_EMBED_TIMEOUT_SECS` (default 10) — drives the `reqwest::Client` timeout for the embed call

Both default to the existing hardcoded values when unset or zero, so behavior for any existing deployment is unchanged.

## Motivation

Two problems running omem-server with non-default models or on slower hardware:

1. **Hardcoded `dims: 1024`** at `OpenAICompatEmbedder::new()` means any model whose native dim != 1024 produces vectors the Lance store can't store. Affects `nomic-embed-text` (768), `bge-small-en-v1.5` (384), `all-MiniLM-L6-v2` (384), and others — all of these otherwise fail at first write with an Arrow length-mismatch panic.

2. **Hardcoded 10s reqwest timeout** kills inference on CPU-only / older hardware. A single embed call against `mxbai-embed-large` (334M-param BERT) on a 2013 Xeon E5-2697 v2 routinely takes 11-15s under back-to-back load. omem-server returns 500 to the caller; ollama keeps computing and discards the eventual result. Lots of wasted CPU and no writes land.

## Validated end-to-end

On a 2013 Xeon E5-2697 v2 (no AVX2/AVX-512), running ollama with a custom `all-minilm-512` model (384-dim, num_ctx=512):

- Embed call latency: **11-15s** (mxbai-embed-large @ 1024) → **200-500ms** (all-minilm @ 384)
- Memory migration of 185 chunks: **previously failed at 41-67% rate** (timeouts), now **completes with zero failures**

The migration script that exercised this is just `POST /v1/memories` per chunk back-to-back with a 6s spacing.

## Relationship to the schema-flexible dim PR

That PR (still open) makes `LanceStore`'s vector column accept any dim from the embedder. This PR lets the openai-compat embedder actually report a non-1024 dim. Together they unlock smaller/faster embedding models on the openai-compat path. They can land in either order; behavior is back-compat in both directions.

## Back-compat

- `OmemConfig::default()` keeps the existing 1024-dim / 10s-timeout values.
- Existing tests pass unchanged.
- Zero values for either env var fall back to the defaults (guards against misconfig producing zero-length vectors or zero-timeout reqwest behavior).

## Tests

Three new tests on `OpenAICompatEmbedder::new`:

- `embed_dim_from_config_overrides_default` — confirms `dims()` returns the configured value
- `embed_dim_zero_falls_back_to_1024` — guards misconfig
- `embed_timeout_zero_falls_back_to_default` — guards misconfig

## Checklist

- [x] Existing openai_compat tests still pass
- [x] New behavior covered
- [x] Back-compat preserved (`OmemConfig::default()` unchanged, zero values fall back)
- [x] No new dependencies