### PR TITLE
feat(api): expose memory_type on create and update

### DIFF
--- a/omem-server/src/api/handlers/memory.rs
+++ b/omem-server/src/api/handlers/memory.rs
@@ -37,6 +37,7 @@ pub struct CreateMemoryBody {
     #[serde(default)]
     pub tags: Option<Vec<String>>,
     pub source: Option<String>,
+    pub memory_type: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -95,6 +96,7 @@ pub struct UpdateMemoryBody {
     pub content: Option<String>,
     pub tags: Option<Vec<String>>,
     pub state: Option<String>,
+    pub memory_type: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -201,10 +203,15 @@ pub async fn create_memory(
         return Err(OmemError::Validation("content cannot be empty".to_string()));
     }
 
+    let memory_type = match body.memory_type {
+        Some(s) => s.parse().map_err(OmemError::Validation)?,
+        None => MemoryType::Pinned,
+    };
+
     let mut memory = Memory::new(
         &content,
         Category::Preferences,
-        MemoryType::Pinned,
+        memory_type,
         &auth.tenant_id,
     );
     memory.tags = body.tags.unwrap_or_default();
@@ -521,6 +528,12 @@ pub async fn update_memory(
 
     if let Some(state_str) = body.state {
         memory.state = state_str
+            .parse()
+            .map_err(|e: String| OmemError::Validation(e))?;
+    }
+
+    if let Some(memory_type_str) = body.memory_type {
+        memory.memory_type = memory_type_str
             .parse()
             .map_err(|e: String| OmemError::Validation(e))?;
     }

--- a/omem-server/src/api/mod.rs
+++ b/omem-server/src/api/mod.rs
@@ -484,6 +484,145 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_memory_with_type() {
+        let (app, _dir) = setup_app().await;
+        let api_key = create_test_tenant(&app).await;
+
+        // Create with explicit memory_type=insight.
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/memories")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", &api_key)
+                    .body(Body::from(r#"{"content":"an insight","memory_type":"insight"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let bytes = create_resp.into_body().collect().await.expect("body").to_bytes();
+        let created: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(created["memory_type"], "insight");
+
+        // Default (no memory_type) still becomes pinned for backwards compat.
+        let default_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/memories")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", &api_key)
+                    .body(Body::from(r#"{"content":"default"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let bytes = default_resp.into_body().collect().await.expect("body").to_bytes();
+        let default_created: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(default_created["memory_type"], "pinned");
+    }
+
+    #[tokio::test]
+    async fn test_update_memory_type() {
+        let (app, _dir) = setup_app().await;
+        let api_key = create_test_tenant(&app).await;
+
+        // Create a pinned memory (default).
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/memories")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", &api_key)
+                    .body(Body::from(r#"{"content":"originally pinned"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        let bytes = create_resp
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        let created: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let memory_id = created["id"].as_str().expect("id");
+        assert_eq!(created["memory_type"], "pinned");
+
+        // Demote to insight.
+        let update_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/v1/memories/{memory_id}"))
+                    .header("content-type", "application/json")
+                    .header("x-api-key", &api_key)
+                    .body(Body::from(r#"{"memory_type":"insight"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(update_resp.status(), StatusCode::OK);
+
+        let bytes = update_resp
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(json["memory_type"], "insight");
+    }
+
+    #[tokio::test]
+    async fn test_update_memory_type_invalid() {
+        let (app, _dir) = setup_app().await;
+        let api_key = create_test_tenant(&app).await;
+
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/memories")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", &api_key)
+                    .body(Body::from(r#"{"content":"test"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let bytes = create_resp.into_body().collect().await.expect("body").to_bytes();
+        let created: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let memory_id = created["id"].as_str().expect("id");
+
+        // Unknown type should fail validation, not silently accept.
+        let update_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/v1/memories/{memory_id}"))
+                    .header("content-type", "application/json")
+                    .header("x-api-key", &api_key)
+                    .body(Body::from(r#"{"memory_type":"bogus"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(update_resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn test_search_memories() {
         let (app, _dir) = setup_app().await;
         let api_key = create_test_tenant(&app).await;


### PR DESCRIPTION
## Summary

`POST /v1/memories` hardcoded `MemoryType::Pinned` as the default for direct content creation, and `PUT /v1/memories/{id}` had no way to change the type at all. As a result every API-created memory ended up pinned, and there was no recovery path short of delete-and-recreate.

This PR:

- Adds `memory_type: Option<String>` to `CreateMemoryBody`. When provided, the value is parsed via `MemoryType::FromStr` (returns `Validation` / 400 on unknown variants). When absent, the existing default of `Pinned` is preserved so this is **not a breaking change**.
- Adds `memory_type: Option<String>` to `UpdateMemoryBody` with the same parse-and-validate flow.

## Motivation

I ran into this myself. After migrating ~170 memories into my omem instance via the API, every single one ended up `memory_type: pinned` and got the 1.5× `pinned_boost` in `stage_rrf_fusion` — effectively a uniform inflation across the corpus that defeats the boost's purpose. There was no API path to demote them; the only fix was delete-and-recreate.

## Tests

- `test_create_memory_with_type`: `POST` with `memory_type=insight` returns insight; `POST` without it still returns pinned (default-preserved, no regression for existing callers).
- `test_update_memory_type`: `PUT memory_type=insight` on an existing pinned memory demotes it.
- `test_update_memory_type_invalid`: `PUT` with an unknown variant returns `400 Bad Request` rather than silently accepting.

## Note for reviewers

The create-side default of `Pinned` is preserved here intentionally to avoid a behavior change in a single PR. Whether `Insight` would be a better default is worth a separate design discussion — happy to open a follow-up issue if you'd like to push on it.

CI on this PR will still surface the pre-existing `cargo fmt --check` debt and the rustls 0.23 `CryptoProvider` test failures (the latter is what #6 addresses); my new tests rely on the same fix #6 applies, so once #6 lands they'll go green. I validated them locally on my fork with the #6 patch cherry-picked in: all four scoped test buckets pass (store 34/34, retrieve::pipeline 19/19, the new create test 1/1, the new update tests 2/2).
