### PR TITLE
chore: cargo fmt new code in 3472c74 + my test

### DIFF
--- a/omem-server/src/api/mod.rs
+++ b/omem-server/src/api/mod.rs
@@ -1327,7 +1327,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/v1/spaces/{}/members", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}/members",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("content-type", "application/json")
                     .header("x-api-key", &api_key)
                     .body(Body::from(r#"{"user_id":"bob","role":"member"}"#))
@@ -1386,7 +1389,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/v1/spaces/{}/members/alice", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}/members/alice",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("x-api-key", &api_key)
                     .body(Body::empty())
                     .expect("request"),
@@ -1518,7 +1524,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/v1/spaces/{}", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("x-api-key", &api_key)
                     .body(Body::empty())
                     .expect("request"),
@@ -1532,7 +1541,10 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/v1/spaces/{}", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("x-api-key", &api_key)
                     .body(Body::empty())
                     .expect("request"),
@@ -1578,7 +1590,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("PUT")
-                    .uri(format!("/v1/spaces/{}/members/carol", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}/members/carol",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("content-type", "application/json")
                     .header("x-api-key", &api_key)
                     .body(Body::from(r#"{"role":"admin"}"#))

--- a/omem-server/src/retrieve/pipeline.rs
+++ b/omem-server/src/retrieve/pipeline.rs
@@ -1184,7 +1184,10 @@ mod tests {
         ];
 
         let (result, _) = RetrievalPipeline::stage_rrf_normalize(entries);
-        let top = result.iter().find(|e| e.memory.content == "weak-top").unwrap();
+        let top = result
+            .iter()
+            .find(|e| e.memory.content == "weak-top")
+            .unwrap();
         assert!(
             top.rrf_score < 0.25,
             "weak top result should stay below 0.25, got {}",


### PR DESCRIPTION
Tiny fmt sweep — `cargo fmt --all` on top of upstream main. Surfaces two drifts that landed alongside your larger cleanup in 508e9e6:

- 5 long `format!` chains in `api/mod.rs` from your percent-encoding test fix (3472c74) — now wrapped to per-line args
- One `.iter().find().unwrap()` chain in `pipeline.rs` from the `test_rrf_normalize_weak_top_not_inflated` test I added in #9 — now broken across lines

Pure fmt, no logic touched. `cargo fmt -- --check` passes after this; CI will actually run the 379 tests instead of bailing at the fmt step.

## Worth thinking about: how to prevent future fmt drift

Now that you've done the big cleanup, fmt drift is going to keep biting both of us at the same rate until something enforces it pre-commit. Three options in increasing scope, all easy to add — happy to do whichever one you prefer in a follow-up PR (or nothing if you'd rather just keep an eye on it):

1. **Document in CONTRIBUTING.md** — "run `cargo fmt` before committing." Cheapest; relies on discipline.
2. **`.githooks/pre-commit` + a one-line setup note** (`git config core.hooksPath .githooks`). Hook runs `cargo fmt --check` on staged files; rejects the commit if dirty. Contributors opt in once per clone. Common Rust-project pattern.
3. **cargo-husky as a dev-dep** — auto-installs the hook on first `cargo build`. Zero contributor setup, but adds a transitive dev-dep.

Let me know which (if any) and I'll open a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)