### PR TITLE
test(retrieve): install rustls CryptoProvider in reranker tests

### DIFF
--- a/omem-server/src/retrieve/reranker.rs
+++ b/omem-server/src/retrieve/reranker.rs
@@ -128,6 +128,24 @@ impl Reranker {
 mod tests {
     use super::*;
 
+    // rustls 0.23 requires a process-global CryptoProvider to be installed
+    // before any TLS-aware reqwest::Client is constructed. The api tests
+    // install one in setup_app(), but retrieve::reranker tests don't go
+    // through that path — so under `cargo test --lib retrieve::reranker::`
+    // the tests panic with "no process-level CryptoProvider available."
+    // (They appear to pass under `cargo test --lib` because the api tests
+    // happen to run first in the same binary and install the provider as
+    // a side effect — order-dependent.)
+    //
+    // Guarded by Once so the multiple tests sharing this binary don't race.
+    fn install_crypto_provider() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
+
     #[test]
     fn test_from_env_none_provider() {
         std::env::remove_var("OMEM_RERANK_PROVIDER");
@@ -145,6 +163,7 @@ mod tests {
 
     #[test]
     fn test_new_with_endpoint() {
+        install_crypto_provider();
         let reranker = Reranker::new_with_endpoint("jina", "http://localhost:8080/rerank", "key");
         assert_eq!(reranker.provider(), "jina");
         assert_eq!(reranker.endpoint, "http://localhost:8080/rerank");
@@ -152,6 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rerank_empty_documents() {
+        install_crypto_provider();
         let reranker = Reranker::new_with_endpoint("jina", "http://localhost:1/rerank", "key");
         let result = reranker.rerank("query", &[]).await;
         assert!(result.is_ok());
@@ -160,6 +180,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rerank_timeout_returns_error() {
+        install_crypto_provider();
         let reranker = Reranker {
             provider: "jina".to_string(),
             endpoint: "http://192.0.2.1:1/rerank".to_string(),


### PR DESCRIPTION
## Summary

Mirrors the PR #6 pattern for `retrieve::reranker` tests. Adds an own `install_crypto_provider()` helper (guarded by its own `Once`) and calls it from the three reranker tests that construct a `reqwest::Client`.

## Why

The `install_crypto_provider()` from PR #6 lives in `api::tests::setup_app()`. Because rustls's provider install is process-global and guarded by `Once`, the reranker tests *appear* to pass under `cargo test --lib` — but only because the api tests happen to run first in the same test binary, install the provider, and the side effect persists.

Run in isolation, the failure is immediate:

```
$ cargo test --lib retrieve::reranker::
thread 'retrieve::reranker::tests::test_new_with_endpoint' panicked at
  reqwest-0.13.2/src/async_impl/client.rs:2461:5:
  no process-level CryptoProvider available
```

So the green-CI claim from 3472c74 is order-dependent — sound today, sound under `cargo test --lib`, but breaks the moment anyone scopes the test run or cargo's scheduler changes.

## After this PR

```
$ cargo test --no-fail-fast --lib retrieve::reranker::
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured
```

The helper is intentionally a copy rather than a shared utility — two separate `Once` guards in two test modules is safe (both call `install_default()`, which itself returns `Err` after the first call; we ignore that). Promoting it to a shared `mod test_util` is fine if you'd prefer; happy to revise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)