### PR TITLE
ci: restore green CI (protoc install + fmt drift + clippy lints)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install build deps
+        # lance-encoding's build.rs invokes protoc to generate prost
+        # bindings; without this, `cargo clippy` and `cargo test` fail
+        # with "Could not find `protoc`" once they get past the fmt step.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build deps
         # lance-encoding's build.rs invokes protoc to generate prost
-        # bindings; without this, `cargo clippy` and `cargo test` fail
-        # with "Could not find `protoc`" once they get past the fmt step.
+        # bindings. `protobuf-compiler` provides the `protoc` binary;
+        # `libprotobuf-dev` provides the well-known types (e.g.
+        # google/protobuf/empty.proto) under /usr/include/google/protobuf/
+        # that lance-encoding's .proto files import. Both are needed.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends protobuf-compiler
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler libprotobuf-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/omem-server/src/api/handlers/sharing.rs
+++ b/omem-server/src/api/handlers/sharing.rs
@@ -512,32 +512,31 @@ pub async fn batch_share(
 
     use futures::stream::{self, StreamExt};
 
-    let results: Vec<(String, Result<Memory, OmemError>)> =
-        stream::iter(body.memory_ids)
-            .map(|mem_id| {
-                let source_store = source_store.clone();
-                let target_store = target_store.clone();
-                let space_store = state.space_store.clone();
-                let target_space_id = target_space.id.clone();
-                let user_id = auth.tenant_id.clone();
-                let agent_id = agent_id.clone();
-                async move {
-                    let result = share_single(
-                        &source_store,
-                        &target_store,
-                        &space_store,
-                        &mem_id,
-                        &target_space_id,
-                        &user_id,
-                        &agent_id,
-                    )
-                    .await;
-                    (mem_id, result)
-                }
-            })
-            .buffer_unordered(10)
-            .collect()
-            .await;
+    let results: Vec<(String, Result<Memory, OmemError>)> = stream::iter(body.memory_ids)
+        .map(|mem_id| {
+            let source_store = source_store.clone();
+            let target_store = target_store.clone();
+            let space_store = state.space_store.clone();
+            let target_space_id = target_space.id.clone();
+            let user_id = auth.tenant_id.clone();
+            let agent_id = agent_id.clone();
+            async move {
+                let result = share_single(
+                    &source_store,
+                    &target_store,
+                    &space_store,
+                    &mem_id,
+                    &target_space_id,
+                    &user_id,
+                    &agent_id,
+                )
+                .await;
+                (mem_id, result)
+            }
+        })
+        .buffer_unordered(10)
+        .collect()
+        .await;
 
     let mut succeeded = Vec::new();
     let mut failed = Vec::new();

--- a/omem-server/src/api/handlers/sharing.rs
+++ b/omem-server/src/api/handlers/sharing.rs
@@ -513,7 +513,7 @@ pub async fn batch_share(
     use futures::stream::{self, StreamExt};
 
     let results: Vec<(String, Result<Memory, OmemError>)> =
-        stream::iter(body.memory_ids.into_iter())
+        stream::iter(body.memory_ids)
             .map(|mem_id| {
                 let source_store = source_store.clone();
                 let target_store = target_store.clone();
@@ -921,7 +921,7 @@ pub async fn share_all(
 
     use futures::stream::{self, StreamExt};
 
-    let results: Vec<(bool, bool)> = stream::iter(filtered_ids.into_iter())
+    let results: Vec<(bool, bool)> = stream::iter(filtered_ids)
         .map(|mem_id| {
             let source_store = source_store.clone();
             let target_store = target_store.clone();
@@ -1087,7 +1087,7 @@ pub async fn share_all_to_user(
 
     use futures::stream::{self, StreamExt};
 
-    let results: Vec<(bool, bool)> = stream::iter(filtered_ids.into_iter())
+    let results: Vec<(bool, bool)> = stream::iter(filtered_ids)
         .map(|mem_id| {
             let source_store = source_store.clone();
             let target_store = target_store.clone();
@@ -1260,7 +1260,7 @@ pub async fn org_publish(
 
         use futures::stream::{self, StreamExt};
 
-        let results: Vec<(bool, bool)> = stream::iter(memory_ids.clone().into_iter())
+        let results: Vec<(bool, bool)> = stream::iter(memory_ids.clone())
             .map(|mem_id| {
                 let source_store = source_store.clone();
                 let target_store = target_store.clone();

--- a/omem-server/src/api/handlers/stats.rs
+++ b/omem-server/src/api/handlers/stats.rs
@@ -304,7 +304,7 @@ pub async fn get_tags(
         .into_iter()
         .filter(|(_, c)| *c >= params.min_count)
         .collect();
-    tags.sort_by(|a, b| b.1.cmp(&a.1));
+    tags.sort_by_key(|t| std::cmp::Reverse(t.1));
     let total_unique = tags.len();
     tags.truncate(params.limit);
 
@@ -554,7 +554,7 @@ pub async fn get_spaces_stats(
         }
 
         let mut top_categories: Vec<(String, usize)> = category_counts.into_iter().collect();
-        top_categories.sort_by(|a, b| b.1.cmp(&a.1));
+        top_categories.sort_by_key(|c| std::cmp::Reverse(c.1));
         top_categories.truncate(3);
 
         space_stats.push(serde_json::json!({
@@ -758,7 +758,7 @@ pub async fn get_agents_stats(
         }
 
         let mut top_categories: Vec<(String, usize)> = category_counts.into_iter().collect();
-        top_categories.sort_by(|a, b| b.1.cmp(&a.1));
+        top_categories.sort_by_key(|c| std::cmp::Reverse(c.1));
         top_categories.truncate(3);
 
         let share_count = agent_share_counts.get(agent_id).copied().unwrap_or(0);

--- a/omem-server/src/api/mod.rs
+++ b/omem-server/src/api/mod.rs
@@ -1327,7 +1327,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/v1/spaces/{}/members", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}/members",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("content-type", "application/json")
                     .header("x-api-key", &api_key)
                     .body(Body::from(r#"{"user_id":"bob","role":"member"}"#))
@@ -1386,7 +1389,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/v1/spaces/{}/members/alice", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}/members/alice",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("x-api-key", &api_key)
                     .body(Body::empty())
                     .expect("request"),
@@ -1518,7 +1524,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/v1/spaces/{}", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("x-api-key", &api_key)
                     .body(Body::empty())
                     .expect("request"),
@@ -1532,7 +1541,10 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/v1/spaces/{}", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("x-api-key", &api_key)
                     .body(Body::empty())
                     .expect("request"),
@@ -1578,7 +1590,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("PUT")
-                    .uri(format!("/v1/spaces/{}/members/carol", utf8_percent_encode(&space_id, NON_ALPHANUMERIC)))
+                    .uri(format!(
+                        "/v1/spaces/{}/members/carol",
+                        utf8_percent_encode(&space_id, NON_ALPHANUMERIC)
+                    ))
                     .header("content-type", "application/json")
                     .header("x-api-key", &api_key)
                     .body(Body::from(r#"{"role":"admin"}"#))

--- a/omem-server/src/retrieve/pipeline.rs
+++ b/omem-server/src/retrieve/pipeline.rs
@@ -1184,7 +1184,10 @@ mod tests {
         ];
 
         let (result, _) = RetrievalPipeline::stage_rrf_normalize(entries);
-        let top = result.iter().find(|e| e.memory.content == "weak-top").unwrap();
+        let top = result
+            .iter()
+            .find(|e| e.memory.content == "weak-top")
+            .unwrap();
         assert!(
             top.rrf_score < 0.25,
             "weak top result should stay below 0.25, got {}",


### PR DESCRIPTION
## Summary

Peeled back four layers of latent CI brokenness in one PR. Each fix surfaced the next layer:

1. **`cargo fmt -- --check`** — fixed two small drifts (same as #11, which is now closed as superseded).
2. **`protoc` not installed** — added `apt-get install protobuf-compiler` before the rust toolchain step.
3. **`google/protobuf/empty.proto` not found** — also installed `libprotobuf-dev` (well-known proto types live there, not in `protobuf-compiler`).
4. **7 clippy lints in upstream code** treated as errors by `-D warnings`. Rust 1.95 (installed by `dtolnay/rust-toolchain@stable`) added `useless_into_iter` and `unnecessary_sort_by`. Mechanical fixes, no behavior change.

CI was green when the fmt step was failing first because nothing past fmt ran. With each underlying layer fixed, the next surfaced. All four are now addressed.

## Why this was masked until now

For weeks, CI bailed at `cargo fmt -- --check` on 229 sites of fmt drift across upstream main. The fmt cleanup in 508e9e6 unblocked that gate. PR #11 fixed two small fresh fmt drifts on top of that. With fmt finally green, clippy ran — and surfaced first the missing-protoc dep, then the missing-wkt dep, then the new lints.

Nothing in CI was broken by recent contributor changes — it's just layers being peeled back one gate at a time. None of the clippy lints would have failed CI before rust 1.95.

## Three currently-open PRs blocked by this

- ~~#11 — closed as superseded.~~
- #12 (reranker crypto) — will pass after rebase once this lands.
- #14 (memory_supersede) — will pass after rebase once this lands.

## Verified locally

`cargo clippy --lib -- -D warnings` is clean after the lint fixes. Full lib test suite was 386/386 pass on the supersede branch before, no behavior regressions here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)