### PR TITLE
feat(mcp): expose `space` param on memory_search

### DIFF
--- a/plugins/mcp/src/client.ts
+++ b/plugins/mcp/src/client.ts
@@ -83,11 +83,13 @@ export class OmemClient {
     limit = 10,
     scope?: string,
     tags?: string[],
+    space?: string,
   ): Promise<SearchResult[]> {
     const safeQ = query.length > 500 ? query.slice(0, 500) : query;
     const params = new URLSearchParams({ q: safeQ, limit: String(limit) });
     if (scope) params.set("scope", scope);
     if (tags && tags.length > 0) params.set("tags", tags.join(","));
+    if (space) params.set("space", space);
     const res = await this.request<SearchResponse>(
       `/v1/memories/search?${params}`,
     );

--- a/plugins/mcp/src/tools.ts
+++ b/plugins/mcp/src/tools.ts
@@ -55,7 +55,7 @@ export function registerTools(server: McpServer, client: OmemClient): void {
     {
       title: "Search Memories",
       description:
-        "Search stored memories by semantic query. Returns the most relevant memories ranked by similarity.",
+        "Search stored memories by semantic query. Returns the most relevant memories ranked by similarity. By default searches across all spaces the caller has access to (personal + team + organization). Pass `space` to restrict to specific spaces — useful when you want a query scoped to one context (e.g. work-only) or to peek into a non-default space (e.g. 'this question is about something in our team space').",
       inputSchema: {
         query: z.string().describe("Search query"),
         limit: z
@@ -73,15 +73,22 @@ export function registerTools(server: McpServer, client: OmemClient): void {
           .array(z.string())
           .optional()
           .describe("Filter by tags"),
+        space: z
+          .string()
+          .optional()
+          .describe(
+            "Restrict search to specific spaces. Comma-separated space IDs (e.g. 'personal:doc,team:synchresis-work'), a single ID, or 'all' for every accessible space. Omitted = all accessible spaces.",
+          ),
       },
     },
-    async ({ query, limit, scope, tags }) => {
+    async ({ query, limit, scope, tags, space }) => {
       try {
         const results = await client.searchMemories(
           query,
           limit ?? 10,
           scope,
           tags,
+          space,
         );
 
         if (results.length === 0) {


### PR DESCRIPTION
## Summary

The omem server's `/v1/memories/search` endpoint already accepts a `space` query param that filters which spaces to search across (comma-separated IDs, a single ID, or `all`). The MCP plugin's `memory_search` tool didn't expose it, so callers had no way to scope a query to specific spaces from a tool call.

This adds `space?: string` to:
- the `memory_search` tool's input schema
- `searchMemories()` in `client.ts` (passes through to URL params)

## Why this matters

The natural use case is **per-session scoping** (e.g. "this Claude instance defaults to my homelab space") combined with **per-query overrides** ("for this specific question, also look in the synchresis space because the answer's there"). Both work through the same parameter — set as a session default by the caller, or pass per-call.

Without it, an agent can't take a hint like *"the ELINA notes are in the synchresis space"* and run a targeted cross-space query — it'd have to fall back to the default (which may or may not include that space, depending on the user's role and membership).

The server side is already wired (`api/handlers/memory.rs:332` does the comma-split + `'all'` handling). This is just plumbing the client surface to match.

## Compat

- Optional param. Omitting it preserves the existing "search all accessible spaces" behavior.
- No server change required.
- No version bump implied.

## Context

Part of evaluating omem for a team rollout at **Synchresis** (the MSP I work at). The spaces feature is the foundation we'd use to separate canonical org content from personal scratch content; per-query space scoping is what makes the conversational UX work ("this question is about $TOPIC which lives in $SPACE") rather than forcing users to bounce between sessions or maintain mental scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)