### PR TITLE
fix(api): return 413 content_too_long instead of 500 when embedder co…

### DIFF
--- a/omem-server/src/api/error.rs
+++ b/omem-server/src/api/error.rs
@@ -20,9 +20,7 @@ impl IntoResponse for OmemError {
             OmemError::Storage(_)
             | OmemError::Embedding(_)
             | OmemError::Llm(_)
-            | OmemError::Internal(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal_error", None)
-            }
+            | OmemError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error", None),
         };
 
         let message = self.to_string();

--- a/omem-server/src/api/error.rs
+++ b/omem-server/src/api/error.rs
@@ -7,26 +7,35 @@ use crate::domain::error::OmemError;
 
 impl IntoResponse for OmemError {
     fn into_response(self) -> Response {
-        let (status, code) = match &self {
-            OmemError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found"),
-            OmemError::Unauthorized(_) => (StatusCode::UNAUTHORIZED, "unauthorized"),
-            OmemError::Validation(_) => (StatusCode::BAD_REQUEST, "validation_error"),
-            OmemError::RateLimited => (StatusCode::TOO_MANY_REQUESTS, "rate_limited"),
+        let (status, code, hint) = match &self {
+            OmemError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found", None),
+            OmemError::Unauthorized(_) => (StatusCode::UNAUTHORIZED, "unauthorized", None),
+            OmemError::Validation(_) => (StatusCode::BAD_REQUEST, "validation_error", None),
+            OmemError::ContentTooLong { hint, .. } => (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "content_too_long",
+                Some(hint.clone()),
+            ),
+            OmemError::RateLimited => (StatusCode::TOO_MANY_REQUESTS, "rate_limited", None),
             OmemError::Storage(_)
             | OmemError::Embedding(_)
             | OmemError::Llm(_)
-            | OmemError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
+            | OmemError::Internal(_) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal_error", None)
+            }
         };
 
         let message = self.to_string();
         tracing::error!(status = %status, code = code, error = %message, "request error");
 
-        let body = json!({
-            "error": {
-                "code": code,
-                "message": message,
-            }
+        let mut error_obj = json!({
+            "code": code,
+            "message": message,
         });
+        if let Some(hint) = hint {
+            error_obj["hint"] = json!(hint);
+        }
+        let body = json!({ "error": error_obj });
 
         (status, Json(body)).into_response()
     }

--- a/omem-server/src/api/handlers/memory.rs
+++ b/omem-server/src/api/handlers/memory.rs
@@ -20,6 +20,29 @@ use crate::retrieve::RetrievalPipeline;
 use crate::store::lancedb::ListFilter;
 use crate::store::StoreManager;
 
+/// Map an embedder failure to a structured error.
+///
+/// An over-context-window failure is a client-input problem (the content is
+/// too long for the configured embedder), so surface it as `ContentTooLong`
+/// (HTTP 413) rather than a generic 500 with the cause buried in a stringified
+/// upstream error. Any other embed failure stays `Embedding` (500).
+fn map_embed_error(content_len: usize, e: impl std::fmt::Display) -> OmemError {
+    let lc = e.to_string().to_lowercase();
+    if lc.contains("context window")
+        || lc.contains("context length")
+        || lc.contains("input length exceeds")
+        || lc.contains("maximum context")
+    {
+        OmemError::ContentTooLong {
+            length: content_len,
+            hint: "split the content into smaller memories or configure a longer-context embedder"
+                .to_string(),
+        }
+    } else {
+        OmemError::Embedding(format!("failed to embed content: {e}"))
+    }
+}
+
 // ── Request / Response DTOs ──────────────────────────────────────────
 
 #[derive(Deserialize)]
@@ -221,11 +244,12 @@ pub async fn create_memory(
     memory.source = body.source;
     memory.agent_id = auth.agent_id;
 
+    let content_len = content.chars().count();
     let vectors = state
         .embed
         .embed(&[content])
         .await
-        .map_err(|e| OmemError::Embedding(format!("failed to embed content: {e}")))?;
+        .map_err(|e| map_embed_error(content_len, e))?;
     let vector = vectors.into_iter().next();
 
     store.create(&memory, vector.as_deref()).await?;
@@ -569,11 +593,12 @@ pub async fn update_memory(
     memory.updated_at = chrono::Utc::now().to_rfc3339();
 
     let vector = if need_reembed {
+        let content_len = memory.content.chars().count();
         let vectors = state
             .embed
             .embed(&[memory.content.clone()])
             .await
-            .map_err(|e| OmemError::Embedding(format!("failed to embed content: {e}")))?;
+            .map_err(|e| map_embed_error(content_len, e))?;
         vectors.into_iter().next()
     } else {
         None

--- a/omem-server/src/domain/error.rs
+++ b/omem-server/src/domain/error.rs
@@ -25,6 +25,9 @@ pub enum OmemError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error("content too long: {length} chars exceed the embedder's context window")]
+    ContentTooLong { length: usize, hint: String },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…ntext exceeded

Closes #15.

Embedding content longer than the configured embedder's context window is a client-input problem, but it surfaced as 500 internal_error with the real cause buried inside a stringified upstream embedder error (callers had to substring-match "exceeds the context window").

Add OmemError::ContentTooLong { length, hint }, map it to 413 Payload Too Large in the IntoResponse impl, and recognize the over-context signature at the content embed call sites (create + update). Response now:

  {"error":{"code":"content_too_long",
            "message":"content too long: 7410 chars exceed the embedder's context window",
            "hint":"split the content into smaller memories or configure a longer-context embedder"}}

Other embed failures still map to Embedding/500. This is Option A from the issue; pre-flight token estimate (Option B) left as a possible follow-up.