### PR TITLE
fix(api): default direct-content memory_type to Insight, not Pinned

### DIFF
--- a/omem-server/src/api/handlers/memory.rs
+++ b/omem-server/src/api/handlers/memory.rs
@@ -142,7 +142,7 @@ pub struct ListResponseDto {
 ///
 /// Two modes:
 /// - If `messages` present → ingest pipeline (async), returns 202
-/// - If `content` present → create single pinned memory, returns 201
+/// - If `content` present → create single insight memory, returns 201
 pub async fn create_memory(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthInfo>,
@@ -208,7 +208,7 @@ pub async fn create_memory(
 
     let memory_type = match body.memory_type {
         Some(s) => s.parse().map_err(OmemError::Validation)?,
-        None => MemoryType::Pinned,
+        None => MemoryType::Insight,
     };
 
     let mut memory = Memory::new(

--- a/omem-server/src/api/mod.rs
+++ b/omem-server/src/api/mod.rs
@@ -559,7 +559,7 @@ mod tests {
             .expect("body")
             .to_bytes();
         let default_created: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
-        assert_eq!(default_created["memory_type"], "pinned");
+        assert_eq!(default_created["memory_type"], "insight");
     }
 
     #[tokio::test]
@@ -575,7 +575,9 @@ mod tests {
                     .uri("/v1/memories")
                     .header("content-type", "application/json")
                     .header("x-api-key", &api_key)
-                    .body(Body::from(r#"{"content":"originally pinned"}"#))
+                    .body(Body::from(
+                        r#"{"content":"originally pinned","memory_type":"pinned"}"#,
+                    ))
                     .expect("request"),
             )
             .await


### PR DESCRIPTION
Closes #13.

POST /v1/memories with direct content (no memory_type) defaulted to MemoryType::Pinned. Pinned applies a 1.5x pinned_boost in rrf_fusion, so a Pinned default makes the boost apply uniformly across the whole corpus — defeating its purpose. Bulk-created memories all land pinned and the boost becomes a no-op for relative ranking.

Flip the default to Insight (the normal, unboosted variant). Pinning is now an explicit opt-in via memory_type=pinned for curated high-signal memories.

BEHAVIOR CHANGE: memories created via direct content without an explicit memory_type will no longer receive the pinned ranking boost. Existing data is untouched; callers wanting pinning pass memory_type=pinned.