### PR TITLE
fix(store): make LanceStore::update atomic via merge_insert

### DIFF
--- a/omem-server/src/store/lancedb.rs
+++ b/omem-server/src/store/lancedb.rs
@@ -555,18 +555,26 @@ impl LanceStore {
         mem.updated_at = chrono::Utc::now().to_rfc3339();
 
         let table = self.open_table().await?;
-        table
-            .delete(&format!("id = '{}'", escape_sql(&mem.id)))
-            .await
-            .map_err(|e| OmemError::Storage(format!("delete for update failed: {e}")))?;
-
         let batch = self.memory_to_batch(&mem, vector)?;
         let reader = RecordBatchIterator::new(vec![Ok(batch)], self.schema());
-        table
-            .add(Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
-            .execute()
+
+        // Atomic upsert keyed on `id`: in a single committed transaction,
+        // replace the existing row (or insert it if it is somehow absent).
+        //
+        // This replaces a previous delete-then-add sequence, which was NOT
+        // atomic: if the operation was interrupted between the delete and the
+        // re-insert — e.g. the HTTP request was cancelled, so the handler
+        // future was dropped at the `.await` — the row was deleted but never
+        // restored, silently losing the memory. `merge_insert` commits as one
+        // transaction, so an interrupted update either fully applies or not at
+        // all; it can never leave the row deleted-without-replacement.
+        let mut merge = table.merge_insert(&["id"]);
+        merge.when_matched_update_all(None);
+        merge.when_not_matched_insert_all();
+        merge
+            .execute(Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
             .await
-            .map_err(|e| OmemError::Storage(format!("re-insert for update failed: {e}")))?;
+            .map_err(|e| OmemError::Storage(format!("merge-insert for update failed: {e}")))?;
         Ok(())
     }
 
@@ -1091,6 +1099,50 @@ mod tests {
         let after = store.get_by_id(&mem.id).await.unwrap();
         assert!(after.is_some());
         assert_eq!(after.unwrap().state, MemoryState::Deleted);
+    }
+
+    #[tokio::test]
+    async fn test_update_replaces_row_atomically() {
+        // Regression: update() used to delete-then-add, which could lose the
+        // row if interrupted between the two ops. It now upserts via
+        // merge_insert, so the row is always replaced in place — exactly one
+        // copy, never zero.
+        let (store, _dir) = setup().await;
+        let mem = make_memory("t-upd", "original content");
+        store.create(&mem, None).await.unwrap();
+        assert_eq!(store.list(100, 0).await.unwrap().len(), 1);
+
+        let mut fetched = store.get_by_id(&mem.id).await.unwrap().expect("created");
+        let v0 = fetched.version.unwrap_or(0);
+        fetched.content = "updated content".to_string();
+        fetched.l2_content = "updated content".to_string();
+        store.update(&fetched, None).await.unwrap();
+
+        // Exactly one row remains (no duplicate, no loss) with new content + bumped version.
+        let all = store.list(100, 0).await.unwrap();
+        assert_eq!(all.len(), 1, "update must not duplicate or drop the row");
+        let after = store
+            .get_by_id(&mem.id)
+            .await
+            .unwrap()
+            .expect("still present");
+        assert_eq!(after.content, "updated content");
+        assert!(after.version.unwrap_or(0) > v0, "version should increment");
+    }
+
+    #[tokio::test]
+    async fn test_update_upserts_when_row_absent() {
+        // merge_insert's when_not_matched_insert_all means update() inserts the
+        // row if it doesn't exist yet, rather than silently no-op'ing.
+        let (store, _dir) = setup().await;
+        let mem = make_memory("t-ups", "inserted via update");
+        store.update(&mem, None).await.unwrap();
+        let fetched = store.get_by_id(&mem.id).await.unwrap();
+        assert!(
+            fetched.is_some(),
+            "update should upsert when the row is absent"
+        );
+        assert_eq!(fetched.unwrap().content, "inserted via update");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`LanceStore::update()` can **silently lose a memory** if the operation is interrupted partway through. It replaces a row with two separate, independently-committed operations — a `delete` followed by an `add` — and if execution stops between them, the row is deleted but never re-inserted.

## Root cause

```rust
// store/lancedb.rs — update()
table.delete(&format!("id = '{}'", escape_sql(&mem.id))).await?;   // commit #1
// ... build batch ...
table.add(reader).execute().await?;                                // commit #2
```

These are two distinct transactions. If the future is dropped at the second `.await` — which happens whenever the caller's request is cancelled (e.g. an HTTP client disconnects/aborts and the axum handler future is dropped) — the delete has already committed but the add never runs. The row is gone with no replacement.

`soft_delete()` goes through the same `update()` path, so `DELETE /v1/memories/{id}` and `batch_soft_delete` are exposed too: a cancelled delete can drop the row entirely instead of tombstoning it (`state = 'deleted'`).

## When it bites

It's easy to miss because the happy path works and `create()` (a single `add`) is already atomic. It shows up under interruption, and is most likely when an update is slow enough that a client times out and aborts mid-flight — e.g. a content-changing update that re-embeds a large document on a busy/slow host. The result is a memory that "vanished" with no error on the server side.

## Fix

Replace the delete-then-add with a single atomic `merge_insert` upsert keyed on `id`:

```rust
let mut merge = table.merge_insert(&["id"]);
merge.when_matched_update_all(None);
merge.when_not_matched_insert_all();
merge.execute(reader).await?;
```

This commits as one transaction, so an interrupted update **either fully applies or not at all** — it can never leave the row deleted-without-replacement. Behavior is otherwise preserved: the version bump + `updated_at` are still computed before the write, and updating an id that doesn't exist still inserts it (the old delete-no-op + add did the same; `when_not_matched_insert_all` keeps that). Rows are keyed by unique ids, so the single-match update path applies.

## Tests

- `test_update_replaces_row_atomically` — update replaces a row in place: exactly one copy remains (no duplicate, no loss), content + version updated.
- `test_update_upserts_when_row_absent` — update inserts when the row is absent.
- Full suite green (`cargo test`, 381 passed). `cargo fmt --check` and `clippy` clean for the change.

## Notes

`merge_insert` is available in the pinned `lancedb` (0.27). No schema or API changes; purely an internal durability fix in `update()`.
