### PR TITLE
chore: fix rustfmt drift on main

### DIFF
--- a/omem-server/src/api/handlers/sharing.rs
+++ b/omem-server/src/api/handlers/sharing.rs
@@ -2352,10 +2352,7 @@ mod tests {
         assert_eq!(prov.shared_from_memory, mem.id);
         assert_eq!(prov.source_version, Some(2));
 
-        let old = target_store
-            .get_by_id(&old_copy_id)
-            .await
-            .expect("get old");
+        let old = target_store.get_by_id(&old_copy_id).await.expect("get old");
         assert!(old.is_some());
         assert_eq!(
             old.unwrap().state,

--- a/omem-server/src/main.rs
+++ b/omem-server/src/main.rs
@@ -89,7 +89,9 @@ async fn main() {
         config: config.clone(),
         import_semaphore: Arc::new(tokio::sync::Semaphore::new(3)),
         reconcile_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
-        share_rate_limiter: Arc::new(omem_server::api::rate_limit::RateLimiter::new(config.share_rate_per_min)),
+        share_rate_limiter: Arc::new(omem_server::api::rate_limit::RateLimiter::new(
+            config.share_rate_per_min,
+        )),
     });
 
     let app = build_router(state);


### PR DESCRIPTION
## Problem
The `fmt` CI step (`cargo fmt --check`) is currently **failing on `main`**: `omem-server/src/api/handlers/sharing.rs` and `omem-server/src/main.rs` have rustfmt drift. That reds-out CI on `main` and on every PR branched from it (the `fmt` step runs first, so build/clippy/test never get a chance to run).

## Fix
`cargo fmt` with stable rustfmt (1.9.0, matching `dtolnay/rust-toolchain@stable` in CI). Mechanical formatting only — no logic changes.

