### PR TITLE
docs: add TweetClaw OpenClaw memory workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ Full API reference (48+ endpoints): [docs/API.md](docs/API.md)
 | [docs/SHARING.md](docs/SHARING.md) | Memory sharing architecture, flows, and tutorials |
 | [docs/DEPLOY.md](docs/DEPLOY.md) | Docker & AWS deployment guide |
 | [docs/PLUGINS.md](docs/PLUGINS.md) | Plugin installation for all 4 platforms |
+| [docs/TWEETCLAW_OPENCLAW.md](docs/TWEETCLAW_OPENCLAW.md) | OpenClaw workflow for storing TweetClaw X/Twitter research decisions in ourmem |
 | [skills/ourmem/SKILL.md](skills/ourmem/SKILL.md) | AI agent onboarding skill |
 
 ## License

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -187,6 +187,12 @@ openclaw
 # and captures insights after each agent response
 ```
 
+### Companion Workflow: TweetClaw
+
+OpenClaw agents can pair ourmem with TweetClaw when X/Twitter research or social automation needs durable memory. Use TweetClaw for live X/Twitter work such as search tweets, search tweet replies, follower export, user lookup, monitor tweets, webhooks, media workflows, post tweets, post tweet replies, and giveaway draws. Use ourmem to store concise decisions, selected public source URLs, campaign context, and follow-up notes.
+
+See [TweetClaw OpenClaw Memory Workflow](TWEETCLAW_OPENCLAW.md) for install, verification, credential boundaries, and a memory shape that avoids storing secrets or raw exports.
+
 ---
 
 ## 4. MCP Server

--- a/docs/TWEETCLAW_OPENCLAW.md
+++ b/docs/TWEETCLAW_OPENCLAW.md
@@ -1,0 +1,100 @@
+# TweetClaw OpenClaw Memory Workflow
+
+Use this workflow when an OpenClaw agent needs current X/Twitter signals and durable memory. TweetClaw handles the live X/Twitter automation path. ourmem stores the durable decisions, source URLs, selected tweet IDs, research summaries, and team handoff notes.
+
+This keeps live data access and long-term memory separate:
+
+| Layer | Responsibility | Keep out |
+|-------|----------------|----------|
+| TweetClaw | Search tweets, search tweet replies, export followers, look up users, monitor tweets, receive webhooks, upload or download media, post reviewed tweets or replies, and run giveaway draws | ourmem API keys |
+| ourmem | Store concise findings, decisions, campaign context, query notes, review outcomes, and reusable prompts | Xquik API keys, signing keys, cookies, raw direct-message bodies, and raw follower exports |
+
+## Install Both Plugins
+
+```bash
+openclaw plugins install @ourmem/ourmem
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw installs from npm as `@xquik/tweetclaw`. The [TweetClaw GitHub repo](https://github.com/Xquik-dev/tweetclaw) documents the current OpenClaw setup path. Its [ClawHub page](https://clawhub.ai/plugins/@xquik/tweetclaw) is useful for discovery, but the npm package is the install source.
+
+## Configure OpenClaw
+
+Store credentials in OpenClaw plugin config or environment variables. Do not paste credentials into chat prompts, memory records, screenshots, issue text, or logs.
+
+```bash
+openclaw config set plugins.entries.ourmem.config.apiUrl "https://api.ourmem.ai"
+openclaw config set plugins.entries.ourmem.config.apiKey "$OMEM_API_KEY"
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw", "memory_store", "memory_search"]'
+```
+
+Use TweetClaw's `explore` tool before live calls. It searches the local endpoint catalog and does not require credentials. Enable the live `tweetclaw` tool only for sessions where X/Twitter actions are expected.
+
+## Verify Runtime Loading
+
+```bash
+openclaw plugins list
+openclaw plugins inspect tweetclaw --runtime
+```
+
+Expected result:
+
+- `@ourmem/ourmem` is installed and exposes memory tools.
+- TweetClaw loads with `explore` and optional `tweetclaw`.
+- `tools.alsoAllow` includes the tools the agent should be able to call.
+- TweetClaw live calls return setup guidance until an API key or supported payment mode is configured.
+
+## Suggested Agent Flow
+
+Ask the agent to keep the source data temporary and store only durable conclusions:
+
+```text
+Use TweetClaw to search tweets about "OpenClaw memory plugins" from the last 7 days.
+Summarize only public, reusable findings.
+Store a memory with the query, selected tweet URLs or IDs, useful patterns, and follow-up decision.
+Do not store API keys, cookies, direct-message bodies, or raw follower exports.
+```
+
+Useful TweetClaw jobs for memory-backed workflows:
+
+| TweetClaw job | Store in ourmem |
+|---------------|-----------------|
+| Search tweets or search tweet replies | Query, date range, selected URLs, short evidence summary, and follow-up decision |
+| Follower export | Segment summary, count, public profile URLs worth revisiting, and exclusion criteria |
+| User lookup | Public profile facts, relevance notes, and last checked date |
+| Monitor tweets or webhooks | Alert policy, event type, selected event URLs, and decision history |
+| Media upload or media download | Public media URL, usage note, rights or review decision, and related campaign |
+| Post tweets or post tweet replies | Approved copy, reviewer, posted URL, and reason for the reply |
+| Giveaway draws | Eligibility rules, draw URL, winner evidence, and audit note |
+
+## Memory Shape
+
+Keep stored memories compact and auditable:
+
+```json
+{
+  "content": "TweetClaw search for OpenClaw memory plugins on 2026-05-23 found 3 useful public examples. Keep tracking repos that pair OpenClaw plugins with persistent memory and prefer docs PRs with install verification.",
+  "tags": ["tweetclaw", "openclaw", "x-twitter", "research"],
+  "source": "openclaw"
+}
+```
+
+Avoid storing:
+
+- API keys, signing keys, cookies, OAuth tokens, passwords, or session material.
+- Raw direct-message text.
+- Full follower exports.
+- Payment material.
+- Private account identifiers unless the owner approved storing them.
+
+## Team Handoff
+
+When a finding matters beyond one agent, store the memory and share it to a team space:
+
+```text
+Store the TweetClaw research summary in ourmem with tags tweetclaw, openclaw, research.
+Share it with the social-automation team space if it contains a reusable repo candidate or outreach decision.
+```
+
+This lets coding, marketing, and research agents recall the same public X/Twitter evidence without rerunning the same searches or copying credentials between tools.


### PR DESCRIPTION
## Summary

- Add `docs/TWEETCLAW_OPENCLAW.md` with an OpenClaw workflow that pairs TweetClaw live X/Twitter jobs with ourmem durable memory.
- Link the workflow from the OpenClaw plugin section and README documentation table.
- Document credential boundaries so agents store concise findings, selected public URLs, and decisions without storing keys, cookies, raw DMs, or raw follower exports.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- Added-line dash and sensitive-string scan
- `curl` readback for `https://github.com/Xquik-dev/tweetclaw`
- `curl` readback for `https://clawhub.ai/plugins/@xquik/tweetclaw`
- `npm view @xquik/tweetclaw version dist.tarball repository.url homepage --json`
